### PR TITLE
Loosen redis semver range?

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "terminus": "~1.0.11"
   },
   "dependencies": {
-    "redis": "~0.11.0"
+    "redis": ">=0.11.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Hi, thanks for building this module. I really didn't need all of the cruft, bloat and complexity that bull, kue et al. seem to come with.

I hope you'd be up for merging this PR which means that your module can continue to use recent versions of node_redis. The reason being: I don't want two subtly different versions of node_redis in my project if I can avoid it! I ran your tests with the latest version of node_redis (v2.6.2 as of writing) and they pass.

I realise the caveat/danger of not specifying an upper version bound means that potentially a breaking change in a future redis client could break your module. I see two alternatives to not specifying an upper bound:
- specify an upper bound, but this would need to be updated every time a new version (major/minor/patch) of node_redis is published. Perhaps something like greenkeeper.io would be able to automate this?
- remove the node_redis dependency completely and have the consumer supply the client. This would also mean that people have the choice between node_redis and ioredis

Let me know what you think. Cheers! 🌟
