### PR TITLE
Remove redis dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-runat
-=====
+# runat
 
 [![NPM](https://nodei.co/npm/runat.png)](https://nodei.co/npm/runat/)
 
@@ -7,9 +6,12 @@ Runat is a Redis-backed scheduled queue system with a Duplex stream interface.
 
 Schedule tasks in the future, and consume those events when they are supposed to happen via a streaming interface.
 
+As of `v2.0.0` a Redis client must be installed separately and provided as input to `runat`. This means that the consumer of this module is in control of which client version/implementation is used.
+
 ```javascript
 var RunAt = require("runat")
-var queue = RunAt()
+var client = require("redis").createClient() // or `new require('ioredis')`
+var queue = RunAt(client)
 var tail = require("terminus").tail
 
 queue.pipe(tail({objectMode: true}, function (jobKey) {
@@ -30,23 +32,23 @@ Got jobKey 'last' at 1389654376119
 
 ```
 
-API
-===
+# API
 
-`require("runat")([options])`
+`require("runat")(client, [options])`
 ---
 
 Creates an objectMode Duplex stream that accepts jobs of the form: `{runAt: millisecond_timestamp, key: "string_job_key"}` and emits the job keys approximately when scheduled to happen.
 
-This will poll Redis for jobs, and therefor cannot provide millisecond-based scheduling accuracy.
+This will poll Redis for jobs, and therefore cannot provide millisecond-based scheduling accuracy. Polling starts when any of following happens: `read()`, `pipe()` or `on('readable', fn)`
 
 Multiple consumers can connect to, publish, and/or consume work items from the same queue, but only *one* consumer will get any particular job. This means you can safely have multiple workers consuming the queue without work overlap.
 
+`client` should be an instance of a Redis client. `runat` does some basic validation on the argument provided, checking the existence of each client function it intends to use. This means that as well as [node_redis](https://github.com/NodeRedis/node_redis), [ioredis](https://github.com/luin/ioredis) should be compatible, and equally some in memory mocks, e.g. [redis-js](https://github.com/wilkenstein/redis-mock-js).
+
 Options:
-  * queueName: The name of the underlaying Redis storage zset. Any clients that use the same queueName will share events from that queue. Default: "RunAt~default"
-  * interval: millisecond gap between polling for jobs. Default: 100
-  * redis: Redis host/port config. Expect `{host: "hostname", port: 6379}` Default: null
-  * (normal Duplex stream options) -- Though objectMode is forced to be true.
+  * `queueName`: The name of the underlaying Redis storage zset. Any clients that use the same `queueName` will share events from that queue. Default: `"RunAt~default"`
+  * `interval`: millisecond gap between polling for jobs. Default: `100`
+  * (normal Duplex stream options) -- though `objectMode` is forced to be true.
 
 `.write() .read() .pipe()`
 ---
@@ -56,10 +58,9 @@ This provides a traditional Duplex stream.
 `.stop()`
 ---
 
-Shuts down the queue and closes the Redis connection.
+Stops polling the queue. This does not close the Redis client connection. Subsequent `read()` or `pipe()` calls will restart polling.
 
-`Scheduling Jobs`
----
+# Scheduling Jobs
 
 When scheduling a job it expects work as objects of this format: `{runAt: millisecond_timestamp, key: "string_job_key"}`
 
@@ -71,8 +72,7 @@ Because this is a polling system, job timing is only as granular as the polling 
 
 Another important caveat is work jobKeys must be unique. If you attempt to schedule the same work for two different times, the last scheduler wins. This means you can reschedule jobs by giving them a new `runAt` time.
 
-`Getting Work`
----
+# Getting Work
 
 Consuming work is simply setting up a stream consumer that will read from the RunAt stream. The stream is an `objectMode` stream. One suggested easy way to set up a function to be run upon each work item is using [terminus](http://npm.im/terminus) specifically the `terminus.tail` function. This is shown in the example above.
 
@@ -80,8 +80,7 @@ It is up to you to decide what keys to use for your jobs and what they mean.
 
 You may want to consider having the workers reschedule work they cannot complete or having a separate retry queue for errors, or any other configurations that can provide work durability.
 
-`Lost Work`
----
+# Lost Work
 
 There are a few things that could possibly result in lost work from the work queue.
 
@@ -89,7 +88,6 @@ There are a few things that could possibly result in lost work from the work que
   2. Redis could crash, or the zset could be extrnally deleted or truncated outside the scope of this application.
 
 
-LICENSE
-=======
+# LICENSE
 
 MIT

--- a/package.json
+++ b/package.json
@@ -21,12 +21,11 @@
   "author": "Bryce B. Baril",
   "license": "MIT",
   "devDependencies": {
+    "redis": "~2.6.2",
     "tape": "~3.5.0",
     "terminus": "~1.0.11"
   },
-  "dependencies": {
-    "redis": "~0.11.0"
-  },
+  "dependencies": {},
   "repository": {
     "type": "git",
     "url": "git://github.com/brycebaril/runat.git"

--- a/runat.js
+++ b/runat.js
@@ -1,3 +1,5 @@
+'use strict'
+
 module.exports = WorkQueue
 
 var Duplex = require("stream").Duplex

--- a/runat.js
+++ b/runat.js
@@ -28,14 +28,18 @@ WorkQueue.prototype._connect = function _connect() {
 }
 
 WorkQueue.prototype._write = function _write(job, encoding, callback) {
-  if (!job.key)
+  var self = this
+  if (!job.key) {
     self.emit("error", "Schedule jobs via: {runAt: ms_timestamp, key: 'your_job_key'")
+    return
+  }
 
   this._connect()
 
   this.client.zadd(this.queueName, job.runAt || 0, job.key, function zaddReply(err, reply) {
     if (err) {
       self.emit("error", "Error scheduling job: " + err)
+      return
     }
     callback()
   })

--- a/test/index.js
+++ b/test/index.js
@@ -98,3 +98,12 @@ test("receipt", function (t) {
     t.end()
   }, 30)
 })
+
+test("invalid job", function (t) {
+  var c = WQ({queueName: "~invalid~job", interval: 20})
+  c.on('error', function (err) {
+    t.ok(err, 'Received an error event')
+    t.end()
+  })
+  c.write({runAt: 0, key: null})
+})


### PR DESCRIPTION
Hey @brycebaril, as discussed in #1 here's a PR removing the dependency on redis. I used the interface you suggested: `WQ(client, options)`.

Some things to note:
- I removed `client.quit()` from `WorkQueue.prototype.stop`. Since the consumer is providing the client, I don't think it makes sense for us to assume they want the connection closed so let's leave it up to them. As a caveat this meant I had to add `client.quit()` to all of the tests, because the open sockets prevented the test process from terminating.
- I fixed a bug where there was a missing `var self = this` and a missing `return` on error.
- For checking whether a valid client was passed I just check that the argument passed was truthy and that it has all of the methods we want to use. I think that strikes a good balance between flexibility (for mocking, providing different client implementations) and strictness (ensuring we only accept objects provide a valid implementation).

Let me know what you think. Cheers!
