### PR TITLE
Remove unused variable

### DIFF
--- a/runat.js
+++ b/runat.js
@@ -13,8 +13,6 @@ function WorkQueue(options) {
   this.queueName = this.options.queueName || "RunAt~default"
   this.queueInterval = this.options.interval || DEFAULT_INTERVAL_MS
 
-  this._dequedBuffer = []
-
   // force objectMode
   this.options.objectMode = true
 


### PR DESCRIPTION
Couldn't see `this._dequedBuffer` being used in the codebase at all 😄 
